### PR TITLE
Fix protocol mismatch error; implement basic auth for http proxy

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -42,16 +42,22 @@ HTTP.prototype.createConnection = function(options) {
   return new Promise((resolve, reject) => {
     const ssl = options.protocol ? options.protocol.toLowerCase() === 'https:' : false;
     if(ssl && this.options.tunnel === true) {
-      if(options.port === 80) options.port = 443;
+      if(options.port == 80) options.port = 443;
       // CONNECT Method
+      let headers = {
+        host: options.host
+      };
+
+      if (this.proxy.auth) {
+        headers.Authorization = 'Basic ' + Buffer.from(this.proxy.auth).toString('base64');
+      }
+
       const req = http.request({
         host: this.proxy.hostname,
         port: this.proxy.port,
         method: 'CONNECT',
         path: (options.hostname || options.host) + ":" + options.port,
-        headers: {
-          host: options.host
-        },
+        headers,
         timeout: this.options.timeout
       });
 

--- a/src/socks.js
+++ b/src/socks.js
@@ -58,7 +58,7 @@ SOCKS.prototype.createConnection = async function(options) {
     let ip = options.hostname;
     if(lookup && !net.isIP(ip)) {
       ip = await new Promise((resolve, reject) => {
-        dns.lookup(ip, (err, address) => {
+        dns.lookup(ip, { family: this.proxy.protocol == 'socks4' ? 4 : 0 }, (err, address) => {
           if(err) reject(err);
           resolve(address);
         });
@@ -66,7 +66,7 @@ SOCKS.prototype.createConnection = async function(options) {
     }
 
     const ssl = options.protocol ? options.protocol.toLowerCase() === 'https:' : false;
-    if(ssl && this.options.tunnel === true && options.port === 80) options.port = 443;
+    if(ssl && this.options.tunnel === true && options.port == 80) options.port = 443;
     const { socket } = await SocksClient.createConnection({
       proxy: this.proxy,
       command: 'connect',


### PR DESCRIPTION
Under some circumstances the options.port could be '80' string which caused issues with proto mismatch, when the script incorrectly tries to connect to https host via 80 port instead of 443. The line #45 comparison is made less strict to mitigate this.

I also needed basic auth for http proxies. Hopefully this may be useful for someone else. Cheers!